### PR TITLE
Enable SSL for tilde.town

### DIFF
--- a/modules
+++ b/modules
@@ -1,3 +1,4 @@
 hunner-charybdis
 camptocamp-postfix
 jfryman-nginx
+danzilio-letsencrypt


### PR DESCRIPTION
This commit enables ssl on in the web class for tilde.town using
danzilio's letsencrypt module.

NOTE: THIS MIGHT ROYALLY FUCK THINGS UP. WHO KNOWS.
Okay, maybe not royally fuck things up, but the location of the certificate might not end up being `/etc/letsencrypt/live/www.${hostname}/fullchain.pem`. I'm not sure where to look up that behavior for letsencrypt sooooo...

![image](https://cloud.githubusercontent.com/assets/1445303/13545032/78370412-e234-11e5-9294-f1e9406191f5.png)

Even if it doesn't end up being that path it will definitely be in `/etc/letsencrypt/live/` so it is an easy fix regardless.